### PR TITLE
Add C++ WASM build and MSVC-based build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,61 @@ jobs:
           path: |
             build/${{env.BUILD_TYPE}}
           compression-level: 9
+
+  build-windows-msvc2022:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Setup MSVC 2022 environment
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Build library with MSVC 2022
+        shell: cmd
+        run: build.bat %BUILD_TYPE%
+      - name: Run tests (MSVC 2022)
+        shell: pwsh
+        run: ./build/tests/${{env.BUILD_TYPE}}/dcmtkhtj2k_tests.exe
+      - name: Archive MSVC 2022 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dcmtk-htj2k-build-windows-msvc2022
+          path: |
+            build/${{env.BUILD_TYPE}}
+          compression-level: 9
+
+  build-windows-wasm:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Setup Emscripten SDK
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+      - name: Install MinGW
+        shell: pwsh
+        run: choco install mingw --no-progress -y
+      - name: Add MinGW to PATH
+        shell: pwsh
+        run: |
+          $mingwBin = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+          if (!(Test-Path $mingwBin)) {
+            throw "MinGW bin path not found: $mingwBin"
+          }
+          "PATH=$mingwBin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Verify Emscripten and MinGW tools
+        shell: pwsh
+        run: |
+          emcc -v
+          emcmake --version
+          mingw32-make --version
+      - name: Build WASM library
+        shell: cmd
+        run: build_wasm.bat
+      - name: Archive WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dcmtk-htj2k-build-windows-wasm
+          path: |
+            build_wasm/${{env.BUILD_TYPE}}
+          compression-level: 9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,23 +99,64 @@ jobs:
       - name: Install MinGW
         shell: pwsh
         run: choco install mingw --no-progress -y
-      - name: Add MinGW to PATH
+      - name: Ensure MinGW make on PATH
         shell: pwsh
         run: |
-          $mingwBin = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
-          if (!(Test-Path $mingwBin)) {
-            throw "MinGW bin path not found: $mingwBin"
+          # Prefer existing PATH if mingw32-make is already available.
+          $makeCmd = Get-Command mingw32-make.exe -ErrorAction SilentlyContinue
+          if (-not $makeCmd) {
+            $candidate = Get-ChildItem `
+              -Path "C:\ProgramData\chocoportable\lib\mingw\tools\install" `
+              -Recurse -Filter "mingw32-make.exe" `
+              -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+            if (-not $candidate) {
+              throw "mingw32-make.exe not found after MinGW install."
+            }
+            $binDir = Split-Path $candidate.FullName -Parent
+            # In GitHub Actions, update PATH for subsequent steps via GITHUB_PATH.
+            # When running locally, GITHUB_PATH/GITHUB_ENV won't exist, so we update $env:PATH directly.
+            if ($env:GITHUB_PATH) {
+              $binDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            } else {
+              $env:PATH = "$binDir;$env:PATH"
+            }
           }
-          "PATH=$mingwBin;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Verify Emscripten and MinGW tools
-        shell: pwsh
+        shell: cmd
         run: |
+          setlocal EnableExtensions
+          set "EMSDK_ENV="
+          if defined EMSDK if exist "%EMSDK%\emsdk_env.bat" set "EMSDK_ENV=%EMSDK%\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "C:\emsdk\emsdk_env.bat" set "EMSDK_ENV=C:\emsdk\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "%USERPROFILE%\.emsdk\emsdk_env.bat" set "EMSDK_ENV=%USERPROFILE%\.emsdk\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "%USERPROFILE%\emsdk\emsdk_env.bat" set "EMSDK_ENV=%USERPROFILE%\emsdk\emsdk_env.bat"
+
+          if defined EMSDK_ENV (
+            call "%EMSDK_ENV%" >nul
+          )
+
+          where emcc
           emcc -v
+          where emcmake
           emcmake --version
+          where mingw32-make
           mingw32-make --version
       - name: Build WASM library
         shell: cmd
-        run: build_wasm.bat
+        run: |
+          setlocal EnableExtensions
+          set "EMSDK_ENV="
+          if defined EMSDK if exist "%EMSDK%\emsdk_env.bat" set "EMSDK_ENV=%EMSDK%\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "C:\emsdk\emsdk_env.bat" set "EMSDK_ENV=C:\emsdk\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "%USERPROFILE%\.emsdk\emsdk_env.bat" set "EMSDK_ENV=%USERPROFILE%\.emsdk\emsdk_env.bat"
+          if not defined EMSDK_ENV if exist "%USERPROFILE%\emsdk\emsdk_env.bat" set "EMSDK_ENV=%USERPROFILE%\emsdk\emsdk_env.bat"
+
+          if defined EMSDK_ENV (
+            call "%EMSDK_ENV%" >nul
+          )
+
+          build_wasm.bat
       - name: Archive WASM artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ DCMTK-HTJ2K provides HTJ2K codec support for [DCMTK](https://github.com/DCMTK/dc
 - **DCMTK Integration**: Seamless integration with DCMTK codec framework.
 - **Configurable Parameters**: Support for codeblock dimensions, progression order, number of decompositions, fragment sizes, and encoding options.
 - **Cross Platform**: Supports Linux, macOS, and Windows builds.
+- **WebAssembly**: Optional Emscripten build producing a C++ static library that you can link into other WebAssembly projects to build wasm for browser or Node.js (see [Building for WebAssembly](#building-for-webassembly-wasm)).
 
 ## Dependencies
 
@@ -40,6 +41,50 @@ The provided build script automatically downloads, builds, and installs dependen
 - Library files to `build/ReleaseOrDebug/lib/`.
 - Header files to `build/ReleaseOrDebug/include/DCMTKHTJ2K/`.
 - CMake configuration files to `build/ReleaseOrDebug/lib/cmake/DCMTKHTJ2K/`.
+
+### Windows (MSVC)
+
+From **x64 Native Tools Command Prompt for VS 2022** (or with MSVC and CMake on PATH):
+
+```batch
+build.bat [Release|Debug]
+```
+
+Defaults to `Release` if omitted. Output is under `build\Release` or `build\Debug`.
+
+### Building for WebAssembly (WASM)
+
+The project can be built for WebAssembly using Emscripten. The result is a C++ static library, not a standalone wasm binary. You link this library into your own Emscripten project to produce the final wasm file for browser or Node.js.
+
+**Prerequisites**
+
+- [Emscripten SDK (emsdk)](https://emscripten.org/docs/getting_started/downloads.html) — installed and on PATH (`emsdk.bat` available)
+- [CMake](https://cmake.org/) (3.12+)
+- [MinGW](https://www.mingw-w64.org/) with `mingw32-make` on PATH
+
+**Build**
+
+From the project root (e.g. in a normal Command Prompt or PowerShell where emsdk and MinGW are on PATH):
+
+```batch
+build_wasm.bat
+```
+
+This script will:
+
+1. Clone (if needed) **DCMTK** and **OpenJPH** into `ots_wasm/`
+2. Check out DCMTK 3.6.9 and OpenJPH 0.26.0
+3. Apply the Emscripten compatibility patch to DCMTK (see `patches/`)
+4. Build DCMTK and OpenJPH with Emscripten, then build DCMTK-HTJ2K
+
+**Output**
+
+- Libraries and headers: `build_wasm\Release\` (lib, include, CMake config)
+- Static library: `build_wasm\Release\lib\libDCMTKHTJ2K.a` — Emscripten-built archive; link this into your application’s Emscripten build to produce the final wasm file.
+
+**Patches**
+
+- `patches/dcmtk-ofwhere-emscripten.patch` — adds an Emscripten implementation of `OFgetExecutablePath` in DCMTK’s `ofwhere.c` (no real executable path in WASM). See `patches/README.md` for details.
 
 ## Usage
 

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,86 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM Run from "x64 Native Tools Command Prompt for VS 2022" so that MSVC and CMake are available.
+REM Or ensure MSVC 2022 and CMake are on PATH.
+
+if "%1"=="Debug" (
+	set "BUILD_TYPE=Debug"
+) else (
+	set "BUILD_TYPE=Release"
+)
+
+set "BUILD_DIR=%CD%\build"
+set "BUILD_DIR_LIB=%CD%\build\%BUILD_TYPE%"
+set "OTS_DEV_SPACE=%CD%\ots"
+
+if not exist "%OTS_DEV_SPACE%" mkdir "%OTS_DEV_SPACE%"
+cd /d "%OTS_DEV_SPACE%"
+
+if not exist "dcmtk" git clone https://github.com/DCMTK/dcmtk.git
+cd dcmtk
+git fetch
+git checkout -f DCMTK-3.6.9
+if not exist "%BUILD_TYPE%" mkdir "%BUILD_TYPE%"
+cd %BUILD_TYPE%
+
+cmake .. -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DDCMTK_MODULES=ofstd;oficonv;oflog;dcmdata;dcmimgle;dcmimage;dcmjpeg;dcmjpls ^
+	-DDCMTK_ENABLE_STL=OFF ^
+	-DDCMTK_WIDE_CHAR_FILE_IO_FUNCTIONS=OFF ^
+	-DDCMTK_DEFAULT_DICT=builtin ^
+	-DDCMTK_WITH_TIFF=OFF ^
+	-DDCMTK_WITH_PNG=OFF ^
+	-DDCMTK_WITH_OPENSSL=OFF ^
+	-DDCMTK_WITH_XML=OFF ^
+	-DDCMTK_WITH_ZLIB=OFF ^
+	-DDCMTK_WITH_SNDFILE=OFF ^
+	-DDCMTK_WITH_ICONV=ON ^
+	-DDCMTK_WITH_WRAP=OFF ^
+	-DBUILD_APPS=OFF ^
+	-DCMAKE_INSTALL_PREFIX=%OTS_DEV_SPACE%/dcmtk/%BUILD_TYPE% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW ^
+	-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$^<$^<CONFIG:Debug^>:Debug^>
+
+cmake --build . --parallel %NUMBER_OF_PROCESSORS% --config %BUILD_TYPE%
+cmake --install . --config %BUILD_TYPE%
+
+cd /d "%OTS_DEV_SPACE%"
+if not exist "openjph" git clone https://github.com/aous72/openjph.git
+cd openjph
+git fetch
+git checkout -f 0.26.0
+if not exist "%BUILD_TYPE%" mkdir "%BUILD_TYPE%"
+cd %BUILD_TYPE%
+
+cmake .. -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DBUILD_SHARED_LIBS=OFF ^
+	-DOJPH_BUILD_EXECUTABLES=OFF ^
+	-DCMAKE_INSTALL_PREFIX=%OTS_DEV_SPACE%/openjph/%BUILD_TYPE% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW ^
+	-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$^<$^<CONFIG:Debug^>:Debug^>
+
+cmake --build . --parallel %NUMBER_OF_PROCESSORS% --config %BUILD_TYPE%
+cmake --install . --config %BUILD_TYPE%
+
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+if not exist "%BUILD_DIR_LIB%" mkdir "%BUILD_DIR_LIB%"
+cd /d "%BUILD_DIR%"
+
+cmake .. -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DBUILD_SHARED_LIBS=OFF ^
+	-DBUILD_TESTING=ON ^
+	-DDCMTK_ROOT=%OTS_DEV_SPACE%/dcmtk/%BUILD_TYPE% ^
+	-DOPENJPH_DIR=%OTS_DEV_SPACE%/openjph/%BUILD_TYPE%/lib/cmake/openjph ^
+	-DDCMTKHTJ2K_ROOT=%OTS_DEV_SPACE%/dcmtkhtj2k/%BUILD_TYPE% ^
+	-DCMAKE_INSTALL_PREFIX=%BUILD_DIR_LIB% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW ^
+	-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$^<$^<CONFIG:Debug^>:Debug^>
+
+cmake --build . --parallel %NUMBER_OF_PROCESSORS% --config %BUILD_TYPE%
+cmake --install . --config %BUILD_TYPE%
+
+endlocal

--- a/build_wasm.bat
+++ b/build_wasm.bat
@@ -1,0 +1,125 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM Build DCMTK-HTJ2K for WebAssembly using Emscripten (emsdk latest) and mingw32-make.
+REM Prerequisites: Git, CMake, MinGW (mingw32-make on PATH), and emsdk installed.
+REM Ensure emsdk and MinGW are available on PATH.
+
+where emsdk.bat >nul 2>nul
+if errorlevel 1 (
+	echo Warning: emsdk not found on PATH.
+	echo Install emsdk or Add the EMSDK to PATH.
+	echo Install emsdk from: https://emscripten.org/docs/getting_started/downloads.html
+	exit /b 1
+)
+
+REM Ensure mingw32-make is available (MinGW bin on PATH)
+where mingw32-make >nul 2>nul
+if errorlevel 1 (
+	echo Warning: mingw32-make not found on PATH. Add MinGW to PATH.	
+	exit /b 1
+)
+
+set "PROJECT_ROOT=%CD%"
+set "BUILD_TYPE=Release"
+set "OTS_WASM=%CD%\ots_wasm"
+set "BUILD_DIR=%CD%\build_wasm"
+set "BUILD_DIR_LIB=%CD%\build_wasm\%BUILD_TYPE%"
+
+
+if not exist "%OTS_WASM%" mkdir "%OTS_WASM%"
+cd /d "%OTS_WASM%"
+
+REM ----- DCMTK (WASM) -----
+if not exist "dcmtk" git clone https://github.com/DCMTK/dcmtk.git
+cd dcmtk
+git fetch
+git checkout -f DCMTK-3.6.9
+REM Apply Emscripten fix for ofwhere.c (DCMTK unchanged; patch applied at build time)
+call git apply "%PROJECT_ROOT%\patches\dcmtk-ofwhere-emscripten.patch"
+if errorlevel 1 (
+	echo ERROR: Failed to apply patches\dcmtk-ofwhere-emscripten.patch
+	echo Ensure the patch matches your DCMTK version.
+	exit /b 1
+)
+if not exist "%BUILD_TYPE%" mkdir "%BUILD_TYPE%"
+cd %BUILD_TYPE%
+
+call emcmake cmake .. -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make ^
+ 	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+	-DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DDCMTK_MODULES=ofstd;oficonv;oflog;dcmdata;dcmimgle;dcmimage;dcmjpeg;dcmjpls ^
+	-DDCMTK_ENABLE_STL=OFF ^
+	-DDCMTK_WIDE_CHAR_FILE_IO_FUNCTIONS=OFF ^
+	-DDCMTK_DEFAULT_DICT=builtin ^
+	-DDCMTK_WITH_TIFF=OFF ^
+	-DDCMTK_WITH_PNG=OFF ^
+	-DDCMTK_WITH_OPENSSL=OFF ^
+	-DDCMTK_WITH_XML=OFF ^
+	-DDCMTK_WITH_ZLIB=OFF ^
+	-DDCMTK_WITH_SNDFILE=OFF ^
+	-DDCMTK_WITH_ICONV=ON ^
+	-DDCMTK_WITH_WRAP=OFF ^
+	-DBUILD_APPS=OFF ^
+	-DCMAKE_INSTALL_PREFIX=%OTS_WASM%/dcmtk/%BUILD_TYPE% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+REM Continue to make even if cmake returned non-zero (e.g. missing BISON/FLEX)
+
+call emmake mingw32-make -j%NUMBER_OF_PROCESSORS%
+if errorlevel 1 (echo ERROR: DCMTK make failed. & exit /b 1)
+call emmake mingw32-make install
+if errorlevel 1 (echo ERROR: DCMTK install failed. & exit /b 1)
+
+cd /d "%OTS_WASM%"
+
+REM ----- OpenJPH (WASM) -----
+if not exist "openjph" git clone https://github.com/aous72/openjph.git
+cd openjph
+git fetch
+git checkout -f 0.26.0
+if not exist "%BUILD_TYPE%" mkdir "%BUILD_TYPE%"
+cd %BUILD_TYPE%
+
+call emcmake cmake .. -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make ^
+	-DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DBUILD_SHARED_LIBS=OFF ^
+	-DOJPH_BUILD_EXECUTABLES=OFF ^
+	-DCMAKE_INSTALL_PREFIX=%OTS_WASM%/openjph/%BUILD_TYPE% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+
+call emmake mingw32-make -j%NUMBER_OF_PROCESSORS%
+if errorlevel 1 (echo ERROR: OpenJPH make failed. & exit /b 1)
+call emmake mingw32-make install
+if errorlevel 1 (echo ERROR: OpenJPH install failed. & exit /b 1)
+
+REM ----- Main project (DCMTK-HTJ2K) WASM -----
+if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
+if not exist "%BUILD_DIR_LIB%" mkdir "%BUILD_DIR_LIB%"
+cd /d "%BUILD_DIR%"
+
+call emcmake cmake .. -G "MinGW Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make ^
+	-DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+	-DCMAKE_CXX_STANDARD=11 ^
+	-DBUILD_SHARED_LIBS=OFF ^
+	-DBUILD_TESTING=OFF ^
+	-DCMAKE_PREFIX_PATH=%OTS_WASM%/dcmtk/%BUILD_TYPE% ^
+	-DDCMTK_DIR=%OTS_WASM%/dcmtk/%BUILD_TYPE%/lib/cmake/dcmtk ^
+	-DDCMTK_ROOT=%OTS_WASM%/dcmtk/%BUILD_TYPE% ^
+	-DOPENJPH_DIR=%OTS_WASM%/openjph/%BUILD_TYPE%/lib/cmake/openjph ^
+	-DDCMTKHTJ2K_ROOT=%OTS_WASM%/dcmtkhtj2k/%BUILD_TYPE% ^
+	-DCMAKE_INSTALL_PREFIX=%BUILD_DIR_LIB% ^
+	-DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+
+call emmake mingw32-make -j%NUMBER_OF_PROCESSORS%
+if errorlevel 1 (echo ERROR: Main project make failed. & exit /b 1)
+call emmake mingw32-make install
+if errorlevel 1 (echo ERROR: Main project install failed. & exit /b 1)
+
+cd /d "%~dp0"
+echo.
+echo WASM build complete. Output in build_wasm\%BUILD_TYPE%
+endlocal

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,21 @@
+# Patches for DCMTK-HTJ2K Builds
+
+Patches applied at build time to third-party sources. They are intended to be applied on top of the exact versions used by the build scripts.
+
+## dcmtk-ofwhere-emscripten.patch
+
+**Target:** DCMTK `ofstd/libsrc/ofwhere.c`  
+**Used by:** `build_wasm.bat` (WebAssembly / Emscripten build)
+
+**Purpose:** DCMTK’s `ofwhere.c` implements `OFgetExecutablePath()` per platform. Emscripten/WASM has no real executable path. Without this patch, the Emscripten build would hit the `#else` branch and fail with “unsupported platform”.
+
+**Change:** Adds an `#elif defined(__EMSCRIPTEN__)` branch that returns a placeholder path (`"."`) and a zero `dirname_length`, so the rest of DCMTK can build and run under Emscripten.
+
+**Apply manually (if needed):**
+
+```bash
+cd ots_wasm/dcmtk
+git apply /path/to/dcmtk-htj2k/patches/dcmtk-ofwhere-emscripten.patch
+```
+
+If you use a different DCMTK version, the patch may need to be updated to match the current `ofwhere.c` (e.g. line numbers or surrounding `#if` blocks).

--- a/patches/dcmtk-ofwhere-emscripten.patch
+++ b/patches/dcmtk-ofwhere-emscripten.patch
@@ -1,0 +1,32 @@
+diff --git a/ofstd/libsrc/ofwhere.c b/ofstd/libsrc/ofwhere.c
+--- a/ofstd/libsrc/ofwhere.c
++++ b/ofstd/libsrc/ofwhere.c
+@@ -541,7 +541,27 @@
+ 
+ #endif
+ 
++#elif defined(__EMSCRIPTEN__)
++
++#include <string.h>
++
++/* Emscripten/WASM: no real executable path; return a placeholder. */
++int OFgetExecutablePath(char* out, int capacity, int* dirname_length)
++{
++  const char* path = ".";
++  int length = (int)strlen(path);
++
++  if (capacity >= length && out != NULL)
++  {
++    memcpy(out, path, (size_t)length);
++    if (dirname_length)
++      *dirname_length = 0;
++    return length;
++  }
++  return length; /* return required length when capacity too small or out is NULL */
++}
++
+ #else
+ 
+ #error unsupported platform
+ 
+ #endif


### PR DESCRIPTION
Added MSVC build support and C++ WASM build configuration.

Tested with:
- MSVC 2022
- Emscripten for WebAssembly build

This improves portability and allows the library to compile in
browser-based and Windows environments.