### PR TITLE
Included diregist to support RGB

### DIFF
--- a/libsrc/djcodece.cc
+++ b/libsrc/djcodece.cc
@@ -33,6 +33,9 @@
 // dcmimgle includes
 #include "dcmtk/dcmimgle/dcmimage.h" /* for class DicomImage */
 
+// dcmimage includes - registers color image support in dcmimgle
+#include "dcmtk/dcmimage/diregist.h"
+
 // HT-J2K library (OpenJPH) includes
 #include "openjph/ojph_arch.h"
 #include "openjph/ojph_codestream.h"


### PR DESCRIPTION
This pull request makes a small but important change to the `libsrc/djcodece.cc` file to ensure proper support for color images in DICOM processing.

- Added the `#include "dcmtk/dcmimage/diregist.h"` header to register color image support in the `dcmimgle` module, which is necessary for handling color DICOM images correctly.